### PR TITLE
Ability to provide a LIST of privacy channels instead of a single value

### DIFF
--- a/Packages/tlp.udonvoiceutils/Runtime/Examples/DynamicPrivacy.cs
+++ b/Packages/tlp.udonvoiceutils/Runtime/Examples/DynamicPrivacy.cs
@@ -5,6 +5,7 @@ using TLP.UdonVoiceUtils.Runtime.Core;
 using UdonSharp;
 using UnityEngine;
 using UnityEngine.Serialization;
+using VRC.SDK3.Data;
 using VRC.SDKBase;
 
 namespace TLP.UdonVoiceUtils.Runtime.Examples
@@ -28,13 +29,23 @@ namespace TLP.UdonVoiceUtils.Runtime.Examples
         [SerializeField]
         private PlayerAudioOverride OverrideWithDynamicPrivacy;
 
+        [Header("Privacy Channel Settings")]
+        [SerializeField]
+        [Tooltip("Privacy channels to set when player is added to the zone")]
+        private int[] PlayerAddedPrivacyChannelIds;
 
         [SerializeField]
-        private int PlayerAddedPrivacyChannelId;
+        [Tooltip("Privacy channels to set when player exits the zone")]
+        private int[] PlayerExitedPrivacyChannelIds;
+
+        [Header("Advanced Settings")]
+        [SerializeField]
+        [Tooltip("If true, adds channels to existing list. If false, replaces entire list.")]
+        private bool AdditiveModeOnEnter = false;
 
         [SerializeField]
-        private int PlayerExitedPrivacyChannelId;
-
+        [Tooltip("If true, removes only specified channels on exit. If false, replaces entire list.")]
+        private bool RemoveModeOnExit = false;
 
         #region Lifecylce
         public void OnEnable() {
@@ -120,9 +131,34 @@ namespace TLP.UdonVoiceUtils.Runtime.Examples
 #endif
             #endregion
 
-            if (Utilities.IsValid(OverrideWithDynamicPrivacy)) {
-                OverrideWithDynamicPrivacy.PrivacyChannelId = PlayerAddedPrivacyChannelId;
+            if (!Utilities.IsValid(OverrideWithDynamicPrivacy)) {
+                return;
             }
+
+            if (PlayerAddedPrivacyChannelIds == null || PlayerAddedPrivacyChannelIds.Length == 0) {
+                #region TLP_DEBUG
+#if TLP_DEBUG
+                DebugLog("No privacy channels to add on player enter");
+#endif
+                #endregion
+                return;
+            }
+
+            if (AdditiveModeOnEnter) {
+                // Add channels to existing list
+                for (int i = 0; i < PlayerAddedPrivacyChannelIds.Length; i++) {
+                    OverrideWithDynamicPrivacy.AddPrivacyChannel(PlayerAddedPrivacyChannelIds[i]);
+                }
+            } else {
+                // Replace entire list
+                SetPrivacyChannels(PlayerAddedPrivacyChannelIds);
+            }
+
+            #region TLP_DEBUG
+#if TLP_DEBUG
+            DebugLog($"Updated privacy channels on player enter. Channel count: {OverrideWithDynamicPrivacy.PrivacyChannelIds.Count}");
+#endif
+            #endregion
         }
 
         internal void OnLocalPlayerRemoved() {
@@ -132,9 +168,104 @@ namespace TLP.UdonVoiceUtils.Runtime.Examples
 #endif
             #endregion
 
-            if (Utilities.IsValid(OverrideWithDynamicPrivacy)) {
-                OverrideWithDynamicPrivacy.PrivacyChannelId = PlayerExitedPrivacyChannelId;
+            if (!Utilities.IsValid(OverrideWithDynamicPrivacy)) {
+                return;
             }
+
+            if (RemoveModeOnExit) {
+                // Remove specific channels
+                if (PlayerExitedPrivacyChannelIds != null && PlayerExitedPrivacyChannelIds.Length > 0) {
+                    for (int i = 0; i < PlayerExitedPrivacyChannelIds.Length; i++) {
+                        OverrideWithDynamicPrivacy.RemovePrivacyChannel(PlayerExitedPrivacyChannelIds[i]);
+                    }
+                }
+            } else {
+                // Replace entire list
+                if (PlayerExitedPrivacyChannelIds != null && PlayerExitedPrivacyChannelIds.Length > 0) {
+                    SetPrivacyChannels(PlayerExitedPrivacyChannelIds);
+                } else {
+                    // Clear all channels
+                    ClearPrivacyChannels();
+                }
+            }
+
+            #region TLP_DEBUG
+#if TLP_DEBUG
+            DebugLog($"Updated privacy channels on player exit. Channel count: {OverrideWithDynamicPrivacy.PrivacyChannelIds.Count}");
+#endif
+            #endregion
+        }
+        #endregion
+
+        #region Helper Methods
+        /// <summary>
+        /// Set the privacy channels to the specified array, replacing any existing channels
+        /// </summary>
+        /// <param name="channelIds">Array of channel IDs to set</param>
+        private void SetPrivacyChannels(int[] channelIds) {
+            if (!Utilities.IsValid(OverrideWithDynamicPrivacy)) {
+                return;
+            }
+
+            // Clear existing channels
+            ClearPrivacyChannels();
+
+            // Add new channels
+            if (channelIds != null && channelIds.Length > 0) {
+                for (int i = 0; i < channelIds.Length; i++) {
+                    OverrideWithDynamicPrivacy.AddPrivacyChannel(channelIds[i]);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Clear all privacy channels
+        /// </summary>
+        private void ClearPrivacyChannels() {
+            if (!Utilities.IsValid(OverrideWithDynamicPrivacy)) {
+                return;
+            }
+
+            if (OverrideWithDynamicPrivacy.PrivacyChannelIdsList == null) {
+                OverrideWithDynamicPrivacy.PrivacyChannelIdsList = new DataList();
+            } else {
+                OverrideWithDynamicPrivacy.PrivacyChannelIdsList.Clear();
+            }
+        }
+
+        /// <summary>
+        /// Public method to manually add a privacy channel
+        /// </summary>
+        /// <param name="channelId">Channel ID to add</param>
+        public void AddPrivacyChannel(int channelId) {
+            if (Utilities.IsValid(OverrideWithDynamicPrivacy)) {
+                OverrideWithDynamicPrivacy.AddPrivacyChannel(channelId);
+            }
+        }
+
+        /// <summary>
+        /// Public method to manually remove a privacy channel
+        /// </summary>
+        /// <param name="channelId">Channel ID to remove</param>
+        public void RemovePrivacyChannel(int channelId) {
+            if (Utilities.IsValid(OverrideWithDynamicPrivacy)) {
+                OverrideWithDynamicPrivacy.RemovePrivacyChannel(channelId);
+            }
+        }
+
+        /// <summary>
+        /// Public method to manually set all privacy channels
+        /// </summary>
+        /// <param name="channelIds">Array of channel IDs to set</param>
+        public void SetPrivacyChannelsPublic(int[] channelIds) {
+            SetPrivacyChannels(channelIds);
+        }
+
+        /// <summary>
+        /// Public method to manually clear all privacy channels
+        /// </summary>
+        public void ClearAllPrivacyChannels() {
+            ClearPrivacyChannels();
         }
         #endregion
     }


### PR DESCRIPTION
**This PR is a proof of concept for a working privacy channel list system instead of a single value**

### Why?
I wanted to create audio zones for my house and needed the ability to have "transition zones"
For example, I wanted the stairway to be heard from both the bottom floor (near the stairs) and the top floor (near the stairs). But I didn't want the top floor to hear the bottom floor when not near the stairs

I didn't find any way to do that so I added this feature to create transition zones, effectively avoiding sudden voice cut when people went upstairs

### Note
This is only a proof of concept I made this quickly so that it works on my map, ideally the channel list may be moved in its own file to prevent helpers functions duplication, I didn't want to do this because it's changing too many things

Moreover, I didn't find any way to do this without this modification but maybe I just missed something and it was possible, the Wiki section of this Github is outdated unfortunately. The demo scene did not provide any example for what I wanted to do.

Lastly, the modification to DynamicPrivacy.cs was not tested, I fixed it quickly with a prompt so I could build. It may or may not work