### PR TITLE
Change MicModel field to public in MicActivation

### DIFF
--- a/Packages/tlp.udonvoiceutils/Runtime/Examples/MicActivation.cs
+++ b/Packages/tlp.udonvoiceutils/Runtime/Examples/MicActivation.cs
@@ -20,7 +20,7 @@ namespace TLP.UdonVoiceUtils.Runtime.Examples
         #endregion
 
         #region State
-        internal MicModel MicModel;
+        public MicModel MicModel;
         #endregion
 
         #region Overrides


### PR DESCRIPTION
The field MicActivation.MicModel needs to be public in order to allow reimplementing/extending the functionality demonstrated in Examples/Microphone/PickupMicrophone.cs